### PR TITLE
Resolve errors when provided with an empty query

### DIFF
--- a/src/Http/Controllers/BlazeController.php
+++ b/src/Http/Controllers/BlazeController.php
@@ -9,6 +9,10 @@ class BlazeController
 {
     public function index(BlazeRequest $request)
     {
+        if (empty($request->get('query'))) {
+            return collect();
+        }
+
         return Blaze::search($request->get('query'));
     }
 }

--- a/src/Http/Requests/BlazeRequest.php
+++ b/src/Http/Requests/BlazeRequest.php
@@ -14,7 +14,7 @@ class BlazeRequest extends FormRequest
     public function rules()
     {
         return [
-            'query' => ['required', 'string'],
+            'query' => ['nullable', 'string'],
         ];
     }
 }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes a small thing where the front-end would receive a 422 validation response from the back-end, after providing an empty query.
