### PR TITLE
Allow closing Blaze window by clicking away

### DIFF
--- a/resources/js/components/Blaze.vue
+++ b/resources/js/components/Blaze.vue
@@ -6,8 +6,8 @@
     height="auto"
     :adaptive="true"
     :pivotY="0.1"
-    @closed="open = false"
     v-on-clickaway="close"
+    @closed="close"
   >
     <div class="bg-grey-20 border-b text-center">
       <input
@@ -215,7 +215,7 @@ export default {
     },
 
     close() {
-      // this.open = false
+      this.open = false;
     },
   },
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request adds the ability to close the Blaze modal/popup by clicking away. Closes #28.
