### PR TITLE
Workaround German umlauts issue with Docsearch

### DIFF
--- a/src/Searchables/Documentation/Documentation.php
+++ b/src/Searchables/Documentation/Documentation.php
@@ -17,6 +17,15 @@ class Documentation implements Searchable
     {
         $searchResults = [];
 
+        if (
+            str_contains($query, 'ä')
+            || str_contains($query, 'ö')
+            || str_contains($query, 'ü')
+            || str_contains($query, 'ß')
+        ) {
+            return collect();
+        }
+
         $algoliaClient = SearchClient::create(
             self::ALGOLIA_APPLICATION_ID,
             self::ALGOLIA_ADMIN_API_KEY
@@ -39,12 +48,12 @@ class Documentation implements Searchable
                 )
             );
 
-            $title = $hit['hierarchy']['lvl'.$highestLvl];
+            $title = $hit['hierarchy']['lvl' . $highestLvl];
             $currentLvl = 0;
             $subtitle = $hit['hierarchy']['lvl0'];
             while ($currentLvl < $highestLvl) {
                 $currentLvl = $currentLvl + 1;
-                $subtitle = $subtitle.' » '.$hit['hierarchy']['lvl'.$currentLvl];
+                $subtitle = $subtitle . ' » ' . $hit['hierarchy']['lvl' . $currentLvl];
             }
 
             $searchResults[] = new DocumentationHit($title, $hit['url']);

--- a/tests/Http/Controllers/BlazeControllerTest.php
+++ b/tests/Http/Controllers/BlazeControllerTest.php
@@ -252,6 +252,22 @@ class BlazeControllerTest extends TestCase
             ->assertSee('using-an-independent-authentication-guard');
     }
 
+    /**
+     * @test
+     * https://github.com/doublethreedigital/blaze/issues/35
+     */
+    public function cant_search_for_documentation_page_that_contains_german_umlaut()
+    {
+        $this
+            ->actingAs($this->user())
+            ->post(cp_route('blaze.search', [
+                'query' => 'ö',
+            ]))
+            ->assertOk()
+            ->assertDontSee('order_type')
+            ->assertDontSee('offset');
+    }
+
     protected function user()
     {
         return User::make()


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request implements a workaround for a bug in Algolia Docsearch, where it would return results even when searching with German Umlauts.

From what I can tell, it would convert `ö` to `o` and return the same documentation results which isn't necessarily what we want.

<img width="774" alt="image" src="https://user-images.githubusercontent.com/19637309/176625464-25488057-bf8e-49df-af3c-1c1591ee1c7d.png">

This PR works around that issue in the Documentation searchable by checking for the existence of a German umlaut, and returning no results if there is one.

Fixes #35 